### PR TITLE
Add Ubuntu Cosmic to CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
       - OS=fedora DIST=27
       - OS=ubuntu DIST=artful
       - OS=ubuntu DIST=bionic
+      - OS=ubuntu DIST=cosmic
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=debian DIST=jessie

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,1 +1,1 @@
-curl -s https://packagecloud.io/install/repositories/tarantool/1_9/script.deb.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.deb.sh | sudo bash

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -1,1 +1,1 @@
-curl -s https://packagecloud.io/install/repositories/tarantool/1_9/script.rpm.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.rpm.sh | sudo bash


### PR DESCRIPTION
Updated dependencies repository to 1_10, because we don't have Ubuntu
Cosmic tarantool packages in 1_9 repository.

Fixes #6.